### PR TITLE
Fix PHP Fatal error 'Class PHPUnit_Framework_TestCase not found in te…

### DIFF
--- a/tests/CostanzoTest.php
+++ b/tests/CostanzoTest.php
@@ -4,7 +4,7 @@ namespace FrancescoMalatesta\Costanzo\Test;
 
 use FrancescoMalatesta\Costanzo\Costanzo;
 
-class CostanzoTest extends \PHPUnit_Framework_TestCase
+class CostanzoTest extends \PHPUnit\Framework\TestCase
 {
     private $costanzo;
 


### PR DESCRIPTION
…sts/CostanzoTest.php on line 7'

<!--- Provide a general summary of your changes in the Title above -->

## Description

Make phpunit run without throwing a "Class not found" fatal error

## Motivation and context

Before this fix, I couldn't run phpunit, because of this error:

`Fatal error: Class 'FrancescoMalatesta\Costanzo\Test\PHPUnit_Framework_TestCase' not found in ....../tests/CostanzoTest.php on line 7`

## How has this been tested?

Run phpunit again, now it works without the above error

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [X] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- [X] I have added tests to cover my changes.
- [X] If my change requires a change to the documentation, I have updated it accordingly.
